### PR TITLE
Remove panic on key error, but return nil

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,7 +71,7 @@ It is the responsibility of the caller to close the file descriptor.
 
 Because this uses `interface{}` to unmarshal json, the structure of json is not required to be predefined. Each `Get()` evaluates the type and extracts accordingly.
 
-## `Get()` function panics if the key is not present
+## `Get()` function ~~panics~~ returns `nil` if the key is not present
 
 Instead of returning an error, `Get()` function panics when trying to fetch an invalid key or trying to read from an invalid index. This is done to easily chain the method as follows
 

--- a/Readme.md
+++ b/Readme.md
@@ -73,10 +73,25 @@ Because this uses `interface{}` to unmarshal json, the structure of json is not 
 
 ## `Get()` function ~~panics~~ returns `nil` if the key is not present
 
-Instead of returning an error, `Get()` function panics when trying to fetch an invalid key or trying to read from an invalid index. This is done to easily chain the method as follows
+Instead of returning an error, `Get()` function ~~panics~~ returns `nil` when trying to fetch an invalid key or trying to read from an invalid index. This is done to easily chain the method as follows
 
 ```go
 Get("foo").Get("bar").Get("", 2)
 ```
 
-without having to evaluate for errors every time.
+without having to evaluate for errors every time or to have to write a `recover` as below.
+
+```go
+defer func() {
+    if r := recover(); r != nil {...}
+```
+
+## `String()` function returns empty string `""` for `nil` values
+
+This is done to avoid the
+
+```bash
+panic: runtime error: invalid memory address or nil pointer dereference
+```
+
+at runtime. Evaluate for `nil` value before applying `String()` method.

--- a/json.go
+++ b/json.go
@@ -33,9 +33,7 @@ type data struct {
 }
 
 // empty type is used to return an empty value so that users can evaluate the return type.
-type empty struct{
-	jsonData
-}
+type empty struct{}
 
 func (e *empty) Get(key string, index ...int) Getter {
 	return e
@@ -47,7 +45,7 @@ func (e *empty) Bytes() []byte {
 
 
 func (e *empty) String() string {
-	return fmt.Sprintf("%s", "")
+	return ""
 }
 
 // Loads load a json string and returns a Getter

--- a/json.go
+++ b/json.go
@@ -72,7 +72,7 @@ func (d *data) Get(key string, index ...int) Getter {
 
 	case map[string]interface{}:
 		if d.jsonData.(map[string]interface{})[key] == nil {
-			panic(fmt.Errorf("key error: %s not found", key))
+			return nil
 		}
 		sliceData.jsonData = d.jsonData.(map[string]interface{})[key]
 

--- a/json.go
+++ b/json.go
@@ -94,6 +94,10 @@ func (d *data) Get(key string, index ...int) Getter {
 		sliceData.jsonData = d.jsonData.(map[string]interface{})[key]
 
 	case []interface{}:
+		if len(d.jsonData.([]interface{})) < (index[0]) {
+			e := new(empty)
+			return e
+		}
 		sliceData.jsonData = d.jsonData.([]interface{})[index[0]]
 
 	default:

--- a/json.go
+++ b/json.go
@@ -32,6 +32,24 @@ type data struct {
 	jsonData
 }
 
+// empty type is used to return an empty value so that users can evaluate the return type.
+type empty struct{
+	jsonData
+}
+
+func (e *empty) Get(key string, index ...int) Getter {
+	return e
+}
+
+func (e *empty) Bytes() []byte {
+	return nil
+}
+
+
+func (e *empty) String() string {
+	return fmt.Sprintf("%s", "")
+}
+
 // Loads load a json string and returns a Getter
 func Loads(b []byte) (Getter, error) {
 	j := new(data)
@@ -72,7 +90,8 @@ func (d *data) Get(key string, index ...int) Getter {
 
 	case map[string]interface{}:
 		if d.jsonData.(map[string]interface{})[key] == nil {
-			return nil
+			e := new(empty)
+			return e
 		}
 		sliceData.jsonData = d.jsonData.(map[string]interface{})[key]
 

--- a/json_test.go
+++ b/json_test.go
@@ -40,15 +40,24 @@ func TestLoads(t *testing.T) {
 	assert.Equal(t, data.String(), "\"Tom Cruise\"", "Should equals Tom Cruise")
 }
 
-func TestNil(t *testing.T) {
+func TestLoadsEmpty(t *testing.T) {
+
+	d, err := Loads([]byte(sampleJSON))
+	assert.Nil(t, err)
+	data := d.Get("Actors").Get("", 0).Get("names").Get("Foo").Get("Bar")
+	assert.Equal(t, data.String(), "", "Should equals \"\"")
+}
+
+func TestEmpty(t *testing.T) {
 
 	d, err := Loads([]byte(sampleJSON))
 	assert.Nil(t, err)
 	data := d.Get("Actors").Get("", 0).Get("names")
+	e := new(empty)
 	if data != nil {
-		assert.Nil(t, data)
+		assert.IsType(t, e, data)
 	} else {
-		assert.Nil(t, data)
+		assert.IsType(t, e, data)
 	}
 }
 

--- a/json_test.go
+++ b/json_test.go
@@ -139,6 +139,15 @@ func TestEmptyByte(t *testing.T) {
 	data := d.Get("Actors").Get("", 0).Get("names").Get("Foo").Bytes()
 	assert.Nil(t, data)
 }
+
+// TestInvalidIndex tests for out of range index number.
+func TestInvalidIndex(t *testing.T) {
+	d, err := Loads([]byte(sampleJSON))
+	assert.Nil(t, err)
+	data := d.Get("Actors").Get("", 200).Get("names").Get("Foo").Bytes()
+	assert.Nil(t, data)
+}
+
 // TestGetFail tests "Not Implemented" part of the Get method.
 func TestGetFail(t *testing.T) {
 	defer func() {

--- a/json_test.go
+++ b/json_test.go
@@ -40,7 +40,8 @@ func TestLoads(t *testing.T) {
 	assert.Equal(t, data.String(), "\"Tom Cruise\"", "Should equals Tom Cruise")
 }
 
-func TestLoadsEmpty(t *testing.T) {
+// TestLoadsEmptyString tests the String method on an empty type. Should return "" for a non-existing key.
+func TestLoadsEmptyString(t *testing.T) {
 
 	d, err := Loads([]byte(sampleJSON))
 	assert.Nil(t, err)
@@ -48,11 +49,12 @@ func TestLoadsEmpty(t *testing.T) {
 	assert.Equal(t, data.String(), "", "Should equals \"\"")
 }
 
+// TestEmpty tests Get on an invalid key for the return type empty. This will prevent the nil pointer dereference error when the key doesn't exist.
 func TestEmpty(t *testing.T) {
 
 	d, err := Loads([]byte(sampleJSON))
 	assert.Nil(t, err)
-	data := d.Get("Actors").Get("", 0).Get("names")
+	data := d.Get("Actors").Get("", 0).Get("names").Get("foo")
 	e := new(empty)
 	if data != nil {
 		assert.IsType(t, e, data)
@@ -130,6 +132,13 @@ func TestDumpAsBytesFail(t *testing.T) {
 	t.Logf("%s", d.Bytes())
 }
 
+// TestEmptyByte tests the Bytes() on the empty type.
+func TestEmptyByte(t *testing.T) {
+	d, err := Loads([]byte(sampleJSON))
+	assert.Nil(t, err)
+	data := d.Get("Actors").Get("", 0).Get("names").Get("Foo").Bytes()
+	assert.Nil(t, data)
+}
 // TestGetFail tests "Not Implemented" part of the Get method.
 func TestGetFail(t *testing.T) {
 	defer func() {

--- a/json_test.go
+++ b/json_test.go
@@ -40,6 +40,14 @@ func TestLoads(t *testing.T) {
 	assert.Equal(t, data.String(), "\"Tom Cruise\"", "Should equals Tom Cruise")
 }
 
+func TestNil(t *testing.T) {
+
+	d, err := Loads([]byte(sampleJSON))
+	assert.Nil(t, err)
+	data := d.Get("Actors").Get("", 0).Get("names")
+	assert.Nil(t, data)
+}
+
 // TestLoadsFail parses an invalid json to test the failure to parse.
 func TestLoadsFail(t *testing.T) {
 	_, err := Loads([]byte(fmt.Sprintf("%s%s", sampleJSON, "invalidJson")))

--- a/json_test.go
+++ b/json_test.go
@@ -45,7 +45,11 @@ func TestNil(t *testing.T) {
 	d, err := Loads([]byte(sampleJSON))
 	assert.Nil(t, err)
 	data := d.Get("Actors").Get("", 0).Get("names")
-	assert.Nil(t, data)
+	if data != nil {
+		assert.Nil(t, data)
+	} else {
+		assert.Nil(t, data)
+	}
 }
 
 // TestLoadsFail parses an invalid json to test the failure to parse.


### PR DESCRIPTION
`Get` method returns a `nil` value instead of panic. This will give the flexibility to do

```golang
data := d.Get("Actors").Get("", 0).Get("names")
	if data != nil {
		...
	} else {
		...
	}
```